### PR TITLE
fix[global]: Default issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-📝.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-📝.md
@@ -2,7 +2,7 @@
 name: "Bug report \U0001F4DD"
 about: Found a bug? Report it!
 title: ""
-labels: Bug \U0001F99F, NEW
+labels: Bug \U0001F99F, NEW, Bug, bug, Bug 🦟, Bug \U+1F99F
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature-request-💡.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-💡.md
@@ -2,7 +2,7 @@
 name: "Feature request \U0001F4A1"
 about: Have a great idea? Tell us!
 title: ""
-labels: Feature \U0001F680, NEW
+labels: Feature \U0001F680, NEW, Feature, feature, Feature 🚀, Feature \U+1F680
 assignees: ''
 
 ---


### PR DESCRIPTION
# Context

## What's changed?
Adding more labels to try and get default labels to populate.

## Does it work?
<!-- pytest / example inc screenshots of it working -->
Needs testing

## Any breaking changes?
<!-- E.g. did you change the inputs/ outputs of a function. -->
N/A

# Checklist
I have:
- [x] Linked an issue and added all necessary info
- [x] Updated the **changelog & docs**
- [x] Self-**reviewed** my PR

<!-- What GH issue does this close? -->
closes #23
